### PR TITLE
fix(goog.module): Use function wrapper instead of eval'ed string.

### DIFF
--- a/lib/googmodule.js
+++ b/lib/googmodule.js
@@ -13,19 +13,14 @@ var createPreprocesor = function(logger) {
 
     log.debug('Processing "%s".', file.originalPath);
 
-    content =
-        content + '\n//# sourceURL=http://googmodule' + file.originalPath;
-    content = JSON.stringify(content);
-
+    // Make sure not to insert any line breaks before the content, so that line
+    // numbers match the original. It's a poor man's source map, essentially.
     var output =
-      '// Generated from ' + file.originalPath + ' by googmodule.js\n' +
-      'try {\n' +
-      // Wrap in a goog.loadModule statement.
-      '  goog.loadModule(' + content + ');\n' +
-      '} catch (e) {\n'+
-      '  if (!e.fileName) e.message += ' + JSON.stringify(' @ ' + file.originalPath) + ';\n' +
-      '  throw e;\n' +
-      '}\n';
+      '/* Generated from ' + file.originalPath + ' by karma-googmodule-preprocessor */ ' +
+      'goog.loadModule(function(exports) { ' +
+      content + ';\n' /* Semicolon insertion may insert ; before EOF, match that. */ +
+      '  return exports;\n' +
+      '});\n';
 
     done(output);
   };

--- a/test/googmodule.spec.js
+++ b/test/googmodule.spec.js
@@ -29,14 +29,11 @@ describe('googmodule loader', function() {
     preprocessor('goog.module(\'my.module\');\ncontent();',
                  {originalPath: '/some/file.js'}, doneFn);
     var expected =
-        '// Generated from /some/file.js by googmodule.js\n' +
-        'try {\n' +
-        '  goog.loadModule("goog.module(\'my.module\');\\n' +
-        'content();\\n//# sourceURL=http://googmodule/some/file.js");\n' +
-        '} catch (e) {\n' +
-        '  if (!e.fileName) e.message += " @ /some/file.js";\n' +
-        '  throw e;\n' +
-        '}\n';
+        '/* Generated from /some/file.js by karma-googmodule-preprocessor */ ' +
+        'goog.loadModule(function(exports) { goog.module(\'my.module\');\n' +
+        'content();;\n' +
+        '  return exports;\n' +
+        '});\n';
     sinon.assert.calledWith(doneFn, expected);
   });
 


### PR DESCRIPTION
This fixes reporting of line numbers for syntax errors in Chrome;
without it, the error is reported on the line containing the eval().

Tested: ran 'grunt test' as well as './run.sh -g googmodule' from
https://github.com/karma-runner/integration-tests (after introducing
these changes into the local node_modules dir).
