### PR TITLE
Add "use strict" to the loaded module

### DIFF
--- a/lib/googmodule.js
+++ b/lib/googmodule.js
@@ -17,7 +17,7 @@ var createPreprocesor = function(logger) {
     // numbers match the original. It's a poor man's source map, essentially.
     var output =
       '/* Generated from ' + file.originalPath + ' by karma-googmodule-preprocessor */ ' +
-      'goog.loadModule(function(exports) { ' +
+      'goog.loadModule(function(exports) { "use strict"; ' +
       content + ';\n' /* Semicolon insertion may insert ; before EOF, match that. */ +
       '  return exports;\n' +
       '});\n';

--- a/test/googmodule.spec.js
+++ b/test/googmodule.spec.js
@@ -30,7 +30,7 @@ describe('googmodule loader', function() {
                  {originalPath: '/some/file.js'}, doneFn);
     var expected =
         '/* Generated from /some/file.js by karma-googmodule-preprocessor */ ' +
-        'goog.loadModule(function(exports) { goog.module(\'my.module\');\n' +
+        'goog.loadModule(function(exports) { "use strict"; goog.module(\'my.module\');\n' +
         'content();;\n' +
         '  return exports;\n' +
         '});\n';


### PR DESCRIPTION
In 2f674a43 I called goog.loadModule with a function instead of a
string, but goog.loadModule does not add "use strict" in that case,
where it previously did.
