### PR TITLE
fix: support Karma's source map handling.

### DIFF
--- a/lib/googmodule.js
+++ b/lib/googmodule.js
@@ -18,7 +18,10 @@ var createPreprocesor = function(logger, /* config.basePath */ basePath) {
 
     log.debug('Processing "%s".', file.originalPath);
 
-    var content = JSON.stringify(content + '\n//# sourceURL=' + relativePath + '\n');
+    // Path must include http:// protocol and '/base/' so that Karma can still recognize the URL
+    // and apply source maps.
+    var content =
+        JSON.stringify(content + '\n//# sourceURL=http://googmodule/base/' + relativePath + '\n');
     // Make sure not to insert any line breaks before the content, so that line
     // numbers match the original. It's a poor man's source map, essentially.
     var output = '/* Generated from ' + relativePath + ' by karma-googmodule-preprocessor */ ' +

--- a/test/googmodule.spec.js
+++ b/test/googmodule.spec.js
@@ -30,7 +30,7 @@ describe('googmodule loader', function() {
                  {originalPath: '/base/path/some/file.js'}, doneFn);
     var expected = '/* Generated from some/file.js by karma-googmodule-preprocessor */ ' +
                    'goog.loadModule("goog.module(\'my.module\');\\ncontent();\\n' +
-                   '//# sourceURL=some/file.js\\n");\n';
+                   '//# sourceURL=http://googmodule/base/some/file.js\\n");\n';
     sinon.assert.calledWith(doneFn, expected);
   });
 


### PR DESCRIPTION
Karma scan stack traces for http:// URLs including a '/base/' segment, then
applies source maps to those. This change adjusts googmodule's effective URLs
to match that expected format.
