### PR TITLE
fix(coverage): avoid eval to allow coverage

### DIFF
--- a/lib/googmodule.js
+++ b/lib/googmodule.js
@@ -24,14 +24,15 @@ var createPreprocesor = function(logger, /* config.basePath */ basePath) {
 
     log.debug('Processing "%s".', file.originalPath);
 
-    // Path must include http:// protocol and '/base/' so that Karma can still recognize the URL
-    // and apply source maps.
-    content =
-        JSON.stringify(content + '\n//# sourceURL=http://googmodule/base/' + relativePath + '\n');
-    // Make sure not to insert any line breaks before the content, so that line
-    // numbers match the original. It's a poor man's source map, essentially.
-    var output = '/* Generated from ' + relativePath + ' by karma-googmodule-preprocessor */ ' +
-                 'goog.loadModule(' + content + ');\n';
+    var output = `/* Generated from ${relativePath} by karma-googmodule-preprocessor */
+goog.loadModule(function(exports) {
+"use strict";
+${content}
+//# sourceURL=http://googmodule/base/${relativePath}
+return exports;
+});
+`;
+
     done(output);
   };
 };

--- a/test/googmodule.spec.js
+++ b/test/googmodule.spec.js
@@ -28,9 +28,16 @@ describe('googmodule loader', function() {
   it('transforms goog.module files', function() {
     preprocessor('goog.module(\'my.module\');\ncontent();',
                  {originalPath: '/base/path/some/file.js'}, doneFn);
-    var expected = '/* Generated from some/file.js by karma-googmodule-preprocessor */ ' +
-                   'goog.loadModule("goog.module(\'my.module\');\\ncontent();\\n' +
-                   '//# sourceURL=http://googmodule/base/some/file.js\\n");\n';
+    var expected = `/* Generated from some/file.js by karma-googmodule-preprocessor */
+goog.loadModule(function(exports) {
+"use strict";
+goog.module('my.module');
+content();
+//# sourceURL=http://googmodule/base/some/file.js
+return exports;
+});
+`;
+
     sinon.assert.calledWith(doneFn, expected);
   });
 


### PR DESCRIPTION
The previous method of putting the content in a single function call as a string prevented subsequent passes from the coverage preprocessor from properly attaching to that code. This uses the non-eval version of the call to `goog.loadModule()` to allow coverage to function properly.

I kept the sourceURL line but I don't think it is doing anything. However, I was able to debug in Chrome with this tiny wrapper script without issues.