### PR TITLE
Change sniff to 50k

### DIFF
--- a/lib/googmodule.js
+++ b/lib/googmodule.js
@@ -12,11 +12,11 @@ var createPreprocesor = function(logger, /* config.basePath */ basePath) {
     if (path.extname(file.originalPath) !== '.js') {
       return done(content);
     }
-    // Only check the first 10k chars, for performance reasons, to avoid
+    // Only check the first characters, for performance reasons, to avoid
     // degenerate behaviour on very large JS files. That's enough to allow
     // for the Apache license, docs, and similar headers.
-    var first10k = content.substring(0, 10000);
-    if (!MODULE_REGEXP.test(first10k) || GOOGBASE_REGEXP.test(first10k) {
+    var sniffRegion = content.substring(0, 50000);
+    if (!MODULE_REGEXP.test(sniffRegion) || GOOGBASE_REGEXP.test(sniffRegion) {
       return done(content);
     }
 

--- a/lib/googmodule.js
+++ b/lib/googmodule.js
@@ -16,7 +16,7 @@ var createPreprocesor = function(logger, /* config.basePath */ basePath) {
     // degenerate behaviour on very large JS files. That's enough to allow
     // for the Apache license, docs, and similar headers.
     var sniffRegion = content.substring(0, 50000);
-    if (!MODULE_REGEXP.test(sniffRegion) || GOOGBASE_REGEXP.test(sniffRegion) {
+    if (!MODULE_REGEXP.test(sniffRegion) || GOOGBASE_REGEXP.test(sniffRegion)) {
       return done(content);
     }
 


### PR DESCRIPTION
This is #23 with the conflicts resolved.

This should allow the `coverage` preprocessor to run before the `googmodule` one.